### PR TITLE
Fix date sorting

### DIFF
--- a/ui/src/components/File.vue
+++ b/ui/src/components/File.vue
@@ -63,6 +63,9 @@
             {{ item.id }}
           </a>
         </template>
+        <template #item.CreatedAt="{ item }">
+            {{ formatDate(item.CreatedAt) }}
+        </template>
       </v-data-table>
     </v-card>
     <v-overlay :value="popup" :absolute="false" :opacity="0.9">
@@ -217,14 +220,7 @@ export default {
         .then((resp) => resp.json())
         .then((data) => {
           this.items = data["files"].map((ele) => {
-            var options = {
-              weekday: "short",
-              year: "numeric",
-              month: "short",
-              day: "numeric",
-            };
             ele.CreatedAt = new Date(ele.CreatedAt);
-            ele.CreatedAt = ele.CreatedAt.toLocaleDateString("en-IN", options);
             return ele;
           });
         });
@@ -236,6 +232,15 @@ export default {
         "/f/" +
         (id ? id : "")
       );
+    },
+    formatDate(date) {
+      const dateObj = date instanceof Date ? date : new Date(date);
+      return dateObj.toLocaleDateString('en-IN', {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
     },
   },
 };

--- a/ui/src/components/Link.vue
+++ b/ui/src/components/Link.vue
@@ -61,8 +61,11 @@
           <a target="_blank" :href="getLink(item.id, true)">
             {{ item.id }}
           </a>
-        </template></v-data-table
-      >
+        </template>
+        <template #item.CreatedAt="{ item }">
+            {{ formatDate(item.CreatedAt) }}
+        </template>
+      </v-data-table>
     </v-card>
     <v-overlay :value="popup" :absolute="false" :opacity="0.9">
       <OnLinkSuccess
@@ -211,14 +214,7 @@ export default {
         .then((resp) => resp.json())
         .then((data) => {
           this.items = data["links"].map((ele) => {
-            var options = {
-              weekday: "short",
-              year: "numeric",
-              month: "short",
-              day: "numeric",
-            };
             ele.CreatedAt = new Date(ele.CreatedAt);
-            ele.CreatedAt = ele.CreatedAt.toLocaleDateString("en-IN", options);
             return ele;
           });
         });
@@ -230,6 +226,15 @@ export default {
         "/l/" +
         (id ? id : "")
       );
+    },
+    formatDate(date) {
+      const dateObj = date instanceof Date ? date : new Date(date);
+      return dateObj.toLocaleDateString('en-IN', {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
     },
   },
 };

--- a/ui/src/components/Text.vue
+++ b/ui/src/components/Text.vue
@@ -65,8 +65,11 @@
           <a target="_blank" :href="getLink(item.id, true)">
             {{ item.id }}
           </a>
-        </template></v-data-table
-      >
+        </template>
+        <template #item.CreatedAt="{ item }">
+            {{ formatDate(item.CreatedAt) }}
+        </template>
+      </v-data-table>
     </v-card>
     <v-overlay :value="popup" :absolute="false" :opacity="0.9">
       <OnLinkSuccess
@@ -217,14 +220,7 @@ export default {
         .then((resp) => resp.json())
         .then((data) => {
           this.items = data["texts"].map((ele) => {
-            var options = {
-              weekday: "short",
-              year: "numeric",
-              month: "short",
-              day: "numeric",
-            };
             ele.CreatedAt = new Date(ele.CreatedAt);
-            ele.CreatedAt = ele.CreatedAt.toLocaleDateString("en-IN", options);
             return ele;
           });
         });
@@ -236,6 +232,15 @@ export default {
         "/t/" +
         (id ? id : "")
       );
+    },
+    formatDate(date) {
+      const dateObj = date instanceof Date ? date : new Date(date);
+      return dateObj.toLocaleDateString('en-IN', {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
     },
   },
 };


### PR DESCRIPTION
Pass Date objects to v-data-table, format them as locale-aware strings using a template.

This allows proper sorting (asc, desc) based on the CreatedAt date, rather than lexicographic sorting on the string version.